### PR TITLE
Improve doc building and hyperlinking

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-# Build the cocotb documentation
+# Build the pyvsc documentation
 #
 # Note: this Makefile is *not* used by Read The Docs, it exec()'s the conf.py
 # file directly. Hence, all special build steps here are only relevant for
@@ -13,7 +13,7 @@ export PATH
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = .venv/bin/sphinx-build
+SPHINXBUILD   = .venv.bld/bin/sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
@@ -23,13 +23,13 @@ help: .venv.bld
 
 .venv.bld: requirements.txt
 	@echo Creating Python venv for Sphinx build
-	python3 -m venv .venv
-	.venv/bin/pip -q install --upgrade pip
-	.venv/bin/pip -q install -r requirements.txt
+	python3 -m venv .venv.bld
+	.venv.bld/bin/pip -q install --upgrade pip
+	.venv.bld/bin/pip -q install -r requirements.txt
 	@touch .venv.bld
 
 .PHONY: clean
-clean: .venv Makefile
+clean: .venv.bld Makefile
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: distclean
@@ -45,4 +45,5 @@ distclean:
 # http://stackoverflow.com/questions/26875072/dependencies-for-special-make-target-default-not-firing
 # We hack around that by calling the target explicitly.
 	make .venv.bld
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+	source .venv.bld/bin/activate; $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,11 +3,10 @@ pyboolector
 Sphinx>=2.1
 sphinx-rtd-theme
 cairosvg
-breathe
+# breathe
 sphinxcontrib-makedomain
 sphinxcontrib-spelling
 pyenchant
 sphinx-issues
 sphinx-argparse
 jinja2
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,15 +49,15 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.makedomain',
-    'sphinx.ext.autosectionlabel',
     'sphinx.ext.inheritance_diagram',
 #    'cairosvgconverter',
-    'breathe',
+#    'breathe',
     'sphinx_issues',
     'sphinxarg.ext',
+    'sphinxcontrib.spelling',
     ]
 
-intersphinx_mapping = {'https://docs.python.org/3': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # Github repo
 issues_github_path = "fvutils/pyvsc"
@@ -107,7 +107,7 @@ autoclass_content = "both"
 exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = "any"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True
@@ -311,7 +311,7 @@ todo_include_todos = True
 # see also https://breathe.readthedocs.io/en/latest/readthedocs.html
 
 env = os.environ.copy()
-env['PATH'] += ':.venv/bin'
+env['PATH'] += ':.venv.bld/bin'
 #subprocess.call('doxygen', cwd='..')
 #subprocess.call(['breathe-apidoc', '-o', 'source/generated', 'source/doxygen/_xml', '-f'], env=env, cwd='..')
 
@@ -325,23 +325,19 @@ env['PATH'] += ':.venv/bin'
 
 # -- Extra setup for spelling check --------------------------------------------
 
-# Spelling check needs an additional module that is not installed by default.
-# Add it only if spelling check is requested so docs can be generated without it.
-
-if 'spelling' in sys.argv:
-    extensions.append("sphinxcontrib.spelling")
-
 # Spelling language.
 spelling_lang = 'en_US'
 tokenizer_lang = spelling_lang
 
 # Location of word list.
-spelling_word_list_filename = ["spelling_wordlist.txt", "c_symbols.txt"]
+spelling_word_list_filename = ["spelling_wordlist.txt",
+                               #"c_symbols.txt"
+]
 
 spelling_ignore_pypi_package_names = False
 spelling_ignore_wiki_words = False
 spelling_show_suggestions = True
 
-# -- Setup for inheritance_diagram directive which uses graphviz ---------------
+# -- Extra setup for inheritance_diagram directive which uses graphviz ---------
 
 graphviz_output_format = 'svg'

--- a/doc/source/coverage.rst
+++ b/doc/source/coverage.rst
@@ -7,7 +7,7 @@ Covergroups
 ===========
 
 With PyVSC, a covergroup is declared as a Python class that is decorated
-with the `@covergroup` decorator.
+with the `covergroup` decorator.
 
 .. code-block:: python3
 

--- a/doc/source/data_types.rst
+++ b/doc/source/data_types.rst
@@ -30,7 +30,7 @@ First, a quick example
             self.c < self.d
             self.b in vsc.rangelist([self.c,self.d])
 
-The example above shows using the ``rand_bit_t`` type to specify class attributes
+The example above shows using the `rand_bit_t` type to specify class attributes
 that are random, unsigned (bit), and 8-bits wide.
 
 In much the same way that C/C++ and SystemVerilog provide more than one way to 
@@ -44,17 +44,17 @@ PyVSC provides a set of standard-width data types, modeled after the types defin
 in stdint.h. Both random and non-random variants of these attribute classes are 
 provided.
 
-=====  ======  ==============  ==============
-Width  Signed  Random          Non-Random
-8      Y       rand_int8_t     int8_t
-8      N       rand_uint8_t    uint8_t
-16     Y       rand_int16_t    int16_t
-16     N       rand_uint16_t   uint16_t
-32     Y       rand_int32_t    int32_t
-32     N       rand_uint32_t   uint32_t
-64     Y       rand_int64_t    int64_t
-64     N       rand_uint64_t   uint64_t
-=====  ======  ==============  ==============
+=====  ======  ===============  ==============
+Width  Signed  Random           Non-Random
+8      Y       `rand_int8_t`    `int8_t`
+8      N       `rand_uint8_t`   `uint8_t`
+16     Y       `rand_int16_t`   `int16_t`
+16     N       `rand_uint16_t`  `uint16_t`
+32     Y       `rand_int32_t`   `int32_t`
+32     N       `rand_uint32_t`  `uint32_t`
+64     Y       `rand_int64_t`   `int64_t`
+64     N       `rand_uint64_t`  `uint64_t`
+=====  ======  ===============  ==============
 
 The constructor for the classes above accepts the initial value for the
 class attribute. By default, the initial value will be 0.
@@ -81,8 +81,8 @@ specifies the initial value for the attribute.
 
 ======  ==============  ==============
 Signed  Random          Non-Random
-Y       rand_int_t      int_t
-N       rand_bit_t      bit_t
+Y       `rand_int_t`    `int_t`
+N       `rand_bit_t`    `bit_t`
 ======  ==============  ==============
 
 .. code-block:: python3
@@ -101,8 +101,8 @@ random unsigned 12-bit attribute.
 Enum-type Attributes
 ====================
 
-PyVSC supports Python Enum and EnumInt enumerated types. Attributes
-are declared using the enum_t and rand_enum_t classes.
+PyVSC supports Python :class:`~enum.Enum` and :class:`~enum.IntEnum` enumerated types. Attributes
+are declared using the `enum_t` and `rand_enum_t` classes.
 
 .. code-block:: python3
     

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -4,59 +4,59 @@ PyVSC Features
 Constraint Features
 
 
-========================  ======  =============  ===  ===========
-Feature                   PyVSC   SystemVerilog  PSS  Description
-<                         Y       Y              Y
->                         Y       Y              Y
-<=                        Y       Y              Y
->=                        Y       Y              Y
-==                        Y       Y              Y
-!=                        Y       Y              Y
-`+`                       Y       Y              Y
-`-`                       Y       Y              Y
-`/`                       Y       Y              Y
-`*`                       Y       Y              Y
-%                         Y       Y              Y
-&                         Y       Y              Y
-`|`                       Y       Y              Y
-`^`                       Y       Y              Y
-&&                        Y (&)   Y              Y
-||                        Y (|)   Y              Y
-<<                        Y       Y              Y
->>                        Y       Y              Y
-~ (unary)                 Y       Y              Y
-unary |                   N       Y              N
-unary &                   N       Y              N
-unary ^                   N       Y              N
-scalar signed field       Y       Y              Y
-scalar unsigned field     Y       Y              Y
-scalar enum field         Y       Y              Y
-scalar fixed-size array   N       Y              Y
-scalar dynamic array      N       Y              N
-class fixed-size array    N       Y              Y
-class dynamic array       N       Y              N
-class (in)equality        N       N              Y
-array sum                 N       Y              Y
-array size                N       Y              Y
-array reduction OR        N       Y              N
-array reduction AND       N       Y              N
-array reduction XOR       N       Y              N
-part select `[bit]`       Y       Y              Y
-part select `[msb:lsb]`   Y       Y              Y
-default                   N       N              Y
-dist                      N       Y              N
-dynamic                   Y       N              Y
-inside (in)               Y       Y              Y
-soft                      Y       Y              N
-solve before              N       Y              N
-unique                    Y       Y              Y
-foreach                   N       Y              Y
-forall                    N       Y              Y
-pre_randomize             Y       Y              Y
-post_randomize            Y       Y              Y
-constraint override       Y       Y              Y
-constraint_mode           Y       Y              N
-========================  ======  =============  ===  ===========
+=========================  ======  =============  ===  ===========
+Feature                    PyVSC   SystemVerilog  PSS  Description
+<                          Y       Y              Y
+>                          Y       Y              Y
+<=                         Y       Y              Y
+>=                         Y       Y              Y
+==                         Y       Y              Y
+!=                         Y       Y              Y
+``+``                      Y       Y              Y
+``-``                      Y       Y              Y
+``/``                      Y       Y              Y
+``*``                      Y       Y              Y
+%                          Y       Y              Y
+&                          Y       Y              Y
+``|``                      Y       Y              Y
+``^``                      Y       Y              Y
+&&                         Y (&)   Y              Y
+||                         Y (|)   Y              Y
+<<                         Y       Y              Y
+>>                         Y       Y              Y
+~ (unary)                  Y       Y              Y
+unary |                    N       Y              N
+unary &                    N       Y              N
+unary ^                    N       Y              N
+scalar signed field        Y       Y              Y
+scalar unsigned field      Y       Y              Y
+scalar enum field          Y       Y              Y
+scalar fixed-size array    N       Y              Y
+scalar dynamic array       N       Y              N
+class fixed-size array     N       Y              Y
+class dynamic array        N       Y              N
+class (in)equality         N       N              Y
+array sum                  N       Y              Y
+array size                 N       Y              Y
+array reduction OR         N       Y              N
+array reduction AND        N       Y              N
+array reduction XOR        N       Y              N
+part select ``[bit]``      Y       Y              Y
+part select ``[msb:lsb]``  Y       Y              Y
+default                    N       N              Y
+dist                       N       Y              N
+dynamic                    Y       N              Y
+inside (in)                Y       Y              Y
+soft                       Y       Y              N
+solve before               N       Y              N
+unique                     Y       Y              Y
+foreach                    N       Y              Y
+forall                     N       Y              Y
+pre_randomize              Y       Y              Y
+post_randomize             Y       Y              Y
+constraint override        Y       Y              Y
+constraint_mode            Y       Y              N
+=========================  ======  =============  ===  ===========
 
 
 Coverage Features


### PR DESCRIPTION
Using ``any`` as the default Sphinx role allows it to discover what to link automatically (when using single backticks) - you only need to be more specific in cases of overloaded names.