### PR TITLE
Fix required pyucis version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
   ],
   install_requires=[
     'pyboolector>=3.2.2',
-    'pyucis>=0.5',
+    'pyucis>=0.0.5',
     'toposort'
   ],
 )


### PR DESCRIPTION
[Recent commit](https://github.com/fvutils/pyvsc/commit/ce1c398f5e182f9db4c54117cc8a02aea716d77b#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7) breaks on dependency installation:
```
root@840bee210d08:/# pip install pyvsc
Collecting pyvsc
  Downloading pyvsc-0.6.0.1361592744-py2.py3-none-any.whl (159 kB)
     |████████████████████████████████| 159 kB 2.5 MB/s
Collecting pyboolector>=3.2.2
  Downloading PyBoolector-3.2.2.20211015.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (2.5 MB)
     |████████████████████████████████| 2.5 MB 13.2 MB/s
Collecting toposort
  Downloading toposort-1.7-py2.py3-none-any.whl (9.0 kB)
ERROR: Could not find a version that satisfies the requirement pyucis>=0.5 (from pyvsc) (from versions: 0.0.0, 0.0.1.20200405.3, 0.0.1.20200405.4, 0.0.1.20200410.1, 0.0.1.20200411.1, 0.0.2.20200809.1, 0.0.2.20200813.1, 0.0.2.20200814.1, 0.0.2.20200815.1, 0.0.2.20200815.2, 0.0.3.20200815.3, 0.0.3.20200908.1, 0.0.3.20201115.1, 0.0.3.20210203.1, 0.0.3.20210221.1, 0.0.4.20210502.1, 0.0.5.20211020.1)
ERROR: No matching distribution found for pyucis>=0.5 (from pyvsc)
```

Ubuntu 20.04 LTS
Python 3.8.10
pip 20.0.2

For some reason installation works on Ubuntu 21.04.