### PR TITLE
Add init of super class as suggested in the issue #99

### DIFF
--- a/src/vsc/model/constraint_expr_model.py
+++ b/src/vsc/model/constraint_expr_model.py
@@ -30,6 +30,7 @@ from vsc.model.expr_model import ExprModel
 class ConstraintExprModel(ConstraintModel):
     
     def __init__(self, e):
+        super().__init__()
         self.e = e
         
     def build(self, btor):


### PR DESCRIPTION
Observed error:
```
  File ".venv/lib/python3.9/site-packages/vsc/model/randomizer.py", line 458, in create_diagnostics
    ret += "  %s:\n" % SourceInfo.toString(pc[0].srcinfo)
AttributeError: 'ConstraintExprModel' object has no attribute 'srcinfo'
```

A fix to a similar problem is suggested in the issue #99.