### PR TITLE
Skip disabled constraints when visiting model; Fixes #173

### DIFF
--- a/src/vsc/model/model_visitor.py
+++ b/src/vsc/model/model_visitor.py
@@ -65,8 +65,7 @@ class ModelVisitor(object):
             
         # Visit constraints
         for c in f.constraint_model_l:
-            if c.enabled:
-                c.accept(self)
+            c.accept(self)
             
     def visit_generator(self, g):
         self.visit_composite_field(g)
@@ -105,7 +104,8 @@ class ModelVisitor(object):
         pass
     
     def visit_constraint_block(self, c : ConstraintBlockModel):
-        self.visit_constraint_scope(c)
+        if c.enabled:
+            self.visit_constraint_scope(c)
         
     def visit_constraint_dynref(self, c):
         c.c.accept(self)

--- a/src/vsc/model/model_visitor.py
+++ b/src/vsc/model/model_visitor.py
@@ -104,8 +104,7 @@ class ModelVisitor(object):
         pass
     
     def visit_constraint_block(self, c : ConstraintBlockModel):
-        if c.enabled:
-            self.visit_constraint_scope(c)
+        self.visit_constraint_scope(c)
         
     def visit_constraint_dynref(self, c):
         c.c.accept(self)

--- a/src/vsc/model/model_visitor.py
+++ b/src/vsc/model/model_visitor.py
@@ -65,7 +65,8 @@ class ModelVisitor(object):
             
         # Visit constraints
         for c in f.constraint_model_l:
-            c.accept(self)
+            if c.enabled:
+                c.accept(self)
             
     def visit_generator(self, g):
         self.visit_composite_field(g)

--- a/src/vsc/visitors/variable_bound_visitor.py
+++ b/src/vsc/visitors/variable_bound_visitor.py
@@ -7,6 +7,7 @@
 from typing import Dict, List
 
 from vsc.model.bin_expr_type import BinExprType
+from vsc.model.constraint_block_model import ConstraintBlockModel
 from vsc.model.constraint_foreach_model import ConstraintForeachModel
 from vsc.model.constraint_if_else_model import ConstraintIfElseModel
 from vsc.model.constraint_implies_model import ConstraintImpliesModel
@@ -102,7 +103,9 @@ class VariableBoundVisitor(ModelVisitor):
             b.update()
 #            print(b.toString())
             
-        
+    def visit_constraint_block(self, c:ConstraintBlockModel):
+        if c.enabled:
+            super().visit_constraint_block(c)
 
     def visit_constraint_if_else(self, c:ConstraintIfElseModel):
         self.depth += 1

--- a/ve/unit/test_constraint_mode.py
+++ b/ve/unit/test_constraint_mode.py
@@ -10,14 +10,36 @@ from vsc_test_case import VscTestCase
 class TestConstraintMode(VscTestCase):
     
     def test_smoke(self):
-        
+
+        # Test that bounds are re-calculated correctly when disabling constraints.
+        # a_zero_c would set bounds to zero, but disabling that constraint zero
+        # should be *nigh* impossible for 1024 bits.
+        # See: https://github.com/fvutils/pyvsc/issues/173
         @vsc.randobj
-        class my_item_c(object):
+        class my_item_0_c(object):
+
+            def __init__(self):
+                self.a = vsc.rand_bit_t(1024)
+
+            @vsc.constraint
+            def a_zero_c(self):
+                self.a == 0
+
+        it = my_item_0_c()
+
+        it.a_zero_c.constraint_mode(False)
+
+        for i in range(16):
+            it.randomize()
+            self.assertNotEqual(it.a, 0)
+
+        @vsc.randobj
+        class my_item_1_c(object):
             
             def __init__(self):
                 self.a = vsc.rand_bit_t(8)
                 self.b = vsc.rand_bit_t(8)
-                
+
             @vsc.constraint
             def ab_eq_c(self):
                 self.a == self.b
@@ -25,10 +47,10 @@ class TestConstraintMode(VscTestCase):
             @vsc.constraint
             def ab_ne_c(self):
                 self.a != self.b
-                
-        it = my_item_c()
 
-        for i in range(16):        
+        it = my_item_1_c()
+
+        for i in range(16):
             it.ab_eq_c.constraint_mode(True)
             it.ab_ne_c.constraint_mode(False)
             it.randomize()
@@ -38,5 +60,3 @@ class TestConstraintMode(VscTestCase):
             it.ab_ne_c.constraint_mode(True)
             it.randomize()
             self.assertNotEqual(it.a, it.b)
-                
-                

--- a/ve/unit/test_constraint_mode.py
+++ b/ve/unit/test_constraint_mode.py
@@ -8,30 +8,8 @@ from unittest.case import TestCase
 from vsc_test_case import VscTestCase
 
 class TestConstraintMode(VscTestCase):
-    
+
     def test_smoke(self):
-
-        # Test that bounds are re-calculated correctly when disabling constraints.
-        # a_zero_c would set bounds to zero, but disabling that constraint zero
-        # should be *nigh* impossible for 1024 bits.
-        # See: https://github.com/fvutils/pyvsc/issues/173
-        @vsc.randobj
-        class my_item_0_c(object):
-
-            def __init__(self):
-                self.a = vsc.rand_bit_t(1024)
-
-            @vsc.constraint
-            def a_zero_c(self):
-                self.a == 0
-
-        it = my_item_0_c()
-
-        it.a_zero_c.constraint_mode(False)
-
-        for i in range(16):
-            it.randomize()
-            self.assertNotEqual(it.a, 0)
 
         @vsc.randobj
         class my_item_1_c(object):
@@ -60,3 +38,29 @@ class TestConstraintMode(VscTestCase):
             it.ab_ne_c.constraint_mode(True)
             it.randomize()
             self.assertNotEqual(it.a, it.b)
+
+    def test_bounds_smoke(self):
+
+        # Test that bounds are re-calculated correctly when disabling constraints.
+        # a_zero_c would set bounds to zero, but disabling that constraint zero
+        # should be *nigh* impossible for 1024 bits.
+        # See: https://github.com/fvutils/pyvsc/issues/173
+
+        @vsc.randobj
+        class my_item_0_c(object):
+
+            def __init__(self):
+                self.a = vsc.rand_bit_t(1024)
+
+            @vsc.constraint
+            def a_zero_c(self):
+                self.a == 0
+
+        it = my_item_0_c()
+
+        it.a_zero_c.constraint_mode(False)
+
+        for i in range(16):
+            it.randomize()
+            self.assertNotEqual(it.a, 0)
+


### PR DESCRIPTION
Traced the bounds processing to ModelVisitor and added a constraint enabled check.

Added a unittest that passes with this commit.