### PR TITLE
Nested soft constraint support

### DIFF
--- a/src/vsc/model/__init__.py
+++ b/src/vsc/model/__init__.py
@@ -37,6 +37,7 @@ from .constraint_model import ConstraintModel
 from .constraint_block_model import ConstraintBlockModel
 from .constraint_expr_model import ConstraintExprModel
 from .constraint_if_else_model import ConstraintIfElseModel
+from .constraint_soft_model import ConstraintSoftModel
 from .constraint_implies_model import ConstraintImpliesModel
 from .constraint_scope_model import ConstraintScopeModel
 from .constraint_unique_model import ConstraintUniqueModel

--- a/src/vsc/model/constraint_expr_model.py
+++ b/src/vsc/model/constraint_expr_model.py
@@ -33,7 +33,7 @@ class ConstraintExprModel(ConstraintModel):
         super().__init__()
         self.e = e
         
-    def build(self, btor):
+    def build(self, btor, soft=False):
         return ExprModel.toBool(btor, self.e.build(btor))
         
     def accept(self, visitor):

--- a/src/vsc/model/constraint_foreach_model.py
+++ b/src/vsc/model/constraint_foreach_model.py
@@ -27,7 +27,7 @@ class ConstraintForeachModel(ConstraintScopeModel):
             False)
         
         
-    def build(self, btor)->'BoolectorNode':
+    def build(self, btor, soft=False)->'BoolectorNode':
         # Unroll the constraints
         size = int(self.lhs.size.get_val())
         ret_l = []
@@ -39,7 +39,7 @@ class ConstraintForeachModel(ConstraintScopeModel):
             # Build out the constraints for this index
             # Note: some could be redundant
             for c in self.constraint_l:
-                ret_l.append(c.build(btor))
+                ret_l.append(c.build(btor, soft))
                 
         return btor.And(*ret_l)
     

--- a/src/vsc/model/constraint_if_else_model.py
+++ b/src/vsc/model/constraint_if_else_model.py
@@ -39,15 +39,15 @@ class ConstraintIfElseModel(ConstraintModel):
         self.true_c : ConstraintModel = true_c
         self.false_c : ConstraintModel = false_c
         
-    def build(self, btor):
+    def build(self, btor, soft=False):
         from vsc.visitors.model_pretty_printer import ModelPrettyPrinter
         cond = ExprModel.toBool(btor, self.cond.build(btor))
-        true_c = self.true_c.build(btor)
+        true_c = self.true_c.build(btor, soft)
        
         if self.false_c == None:
             ret = btor.Implies(cond, true_c)
         else:
-            false_c = self.false_c.build(btor)
+            false_c = self.false_c.build(btor, soft)
             ret = btor.Cond(cond, true_c, false_c)
 
         return ret

--- a/src/vsc/model/constraint_implies_model.py
+++ b/src/vsc/model/constraint_implies_model.py
@@ -30,9 +30,9 @@ class ConstraintImpliesModel(ConstraintScopeModel):
         super().__init__(constraints)
         self.cond = cond
         
-    def build(self, btor):
+    def build(self, btor, soft=False):
         cond = ExprModel.toBool(btor, self.cond.build(btor))
-        body = super().build(btor)
+        body = super().build(btor, soft)
         
         return btor.Implies(cond, body)
     

--- a/src/vsc/model/constraint_model.py
+++ b/src/vsc/model/constraint_model.py
@@ -32,7 +32,7 @@ class ConstraintModel(object):
     def dispose(self):
         self.node = None
     
-    def build(self, btor)->BoolectorNode:
+    def build(self, btor, soft=False)->BoolectorNode:
         raise Exception("build unimplemented for constraint " + str(type(self)))
     
     def get_nodes(self, node_l):

--- a/src/vsc/model/constraint_override_model.py
+++ b/src/vsc/model/constraint_override_model.py
@@ -15,8 +15,8 @@ class ConstraintOverrideModel(ConstraintModel):
         self.orig_constraint = orig_constraint
         self.depth = 1
         
-    def build(self, btor):
-        return self.new_constraint.build(btor)
+    def build(self, btor, soft=False):
+        return self.new_constraint.build(btor, soft)
         
     def accept(self, v):
         v.visit_constraint_override(self)

--- a/src/vsc/model/constraint_scope_model.py
+++ b/src/vsc/model/constraint_scope_model.py
@@ -36,13 +36,15 @@ class ConstraintScopeModel(ConstraintModel):
         self.constraint_l.append(c)
         return c
         
-    def build(self, btor):
+    def build(self, btor, soft=False):
         ret = None
         for c in self.constraint_l:
             if ret is None:
-                ret = c.build(btor)
+                ret = c.build(btor, soft)
             else:
-                ret = btor.And(ret, c.build(btor))
+                b = c.build(btor, soft)
+                if b is not None:
+                    ret = btor.And(ret, b)
              
         if ret is None:
             # An empty block defaults to 'true'

--- a/src/vsc/model/constraint_soft_model.py
+++ b/src/vsc/model/constraint_soft_model.py
@@ -17,9 +17,12 @@ class ConstraintSoftModel(ConstraintModel):
         self.expr = e
         self.priority = 0
 
-    def build(self, btor):
-        return self.expr.build(btor)
-        
+    def build(self, btor, soft=False):
+        if soft:
+            return self.expr.build(btor)
+        else:
+            return None
+
     def accept(self, v):
         v.visit_constraint_soft(self)
         

--- a/src/vsc/model/constraint_unique_model.py
+++ b/src/vsc/model/constraint_unique_model.py
@@ -33,7 +33,7 @@ class ConstraintUniqueModel(ConstraintModel):
         self.unique_l = unique_l
         self.expr = None 
         
-    def build(self, btor):
+    def build(self, btor, soft=False):
         ret = None
 
         # Elements in the unique list might be arrays        

--- a/src/vsc/model/rand_info_builder.py
+++ b/src/vsc/model/rand_info_builder.py
@@ -256,10 +256,11 @@ class RandInfoBuilder(ModelVisitor,RandIF):
                 and_cond = ExprBinModel(and_cond, BinExprType.And, soft_cond)
 
             # TODO Is it okay to add priority attr to root Constraint so
-            #      randomize can sort soft constraints easier?
+            #      add_constraint can detect them and randomize can sort
+            #      soft constraints more easily?
             soft_implies = ConstraintImpliesModel(and_cond, [c])
             soft_implies.priority = c.priority
-            self._active_randset.add_soft_constraint(soft_implies)
+            self._active_randset.add_constraint(soft_implies)
 
         super().visit_constraint_soft(c)
         

--- a/src/vsc/model/rand_info_builder.py
+++ b/src/vsc/model/rand_info_builder.py
@@ -266,14 +266,6 @@ class RandInfoBuilder(ModelVisitor,RandIF):
         if RandInfoBuilder.EN_DEBUG:
             print("<-- RandInfoBuilder::visit_constraint_soft")
 
-    def visit_constraint_scope(self, c : ConstraintScopeModel):
-        for cc in c.constraint_l:
-            cc.accept(self)
-
-        if self._pass == 1:
-            # Filter out all soft constraints
-            c.constraint_l = [cc for cc in c.constraint_l if not isinstance(cc, ConstraintSoftModel)]
-
     def visit_constraint_if_else(self, c : ConstraintIfElseModel):
         self.visit_constraint_stmt_enter(c)
         self._soft_cond_l.append(c.cond)

--- a/src/vsc/model/rand_set.py
+++ b/src/vsc/model/rand_set.py
@@ -76,7 +76,12 @@ class RandSet(object):
     
     def all_fields(self)->List[FieldModel]:
         return self.all_field_l
-        
+
+    def add_soft_constraint(self, c):
+        if c not in self.soft_constraint_s:
+            self.soft_constraint_s.add(c)
+            self.soft_constraint_l.append(c)
+
     def add_constraint(self, c):
         if isinstance(c, ConstraintSoftModel):
             if c not in self.soft_constraint_s:

--- a/src/vsc/model/rand_set.py
+++ b/src/vsc/model/rand_set.py
@@ -77,13 +77,8 @@ class RandSet(object):
     def all_fields(self)->List[FieldModel]:
         return self.all_field_l
 
-    def add_soft_constraint(self, c):
-        if c not in self.soft_constraint_s:
-            self.soft_constraint_s.add(c)
-            self.soft_constraint_l.append(c)
-
     def add_constraint(self, c):
-        if isinstance(c, ConstraintSoftModel):
+        if isinstance(c, ConstraintSoftModel) or hasattr(c, 'priority'):
             if c not in self.soft_constraint_s:
                 self.soft_constraint_s.add(c)
                 self.soft_constraint_l.append(c)

--- a/src/vsc/model/randomizer.py
+++ b/src/vsc/model/randomizer.py
@@ -176,9 +176,8 @@ class Randomizer(RandIF):
                 rs_node_builder.build(rs)
                 n_fields += len(all_fields)
                 
-#                constraint_l.extend(list(map(lambda c:(c,c.build(btor),isinstance(c,ConstraintSoftModel)), rs.constraints())))
-                constraint_l.extend(list(map(lambda c:(c,c.build(btor)), rs.constraints())))
-                soft_constraint_l.extend(list(map(lambda c:(c,c.build(btor)), rs.soft_constraints())))
+                constraint_l.extend(list(map(lambda c:(c,c.build(btor, False)), rs.constraints())))
+                soft_constraint_l.extend(list(map(lambda c:(c,c.build(btor, True)), rs.soft_constraints())))
                 
                 # Sort the list in descending order so we know which constraints
                 # to prioritize

--- a/src/vsc/visitors/model_pretty_printer.py
+++ b/src/vsc/visitors/model_pretty_printer.py
@@ -133,16 +133,23 @@ class ModelPrettyPrinter(ModelVisitor):
             self.dec_indent()
             
         self.writeln("}")
-        
+
+    def visit_constraint_soft(self, c:vm.ConstraintSoftModel):
+        self.write(self.ind + "soft ")
+        c.expr.accept(self)
+        self.write("\n")
+
     def visit_constraint_implies(self, c:vm.ConstraintImpliesModel):
         self.write(self.ind)
         c.cond.accept(self)
-        self.write(" -> {")
+        self.write(" -> {\n")
 
+        self.inc_indent()
         for sc in c.constraint_l:
             sc.accept(self)
-            
-        self.write("}\n")
+        self.dec_indent()
+
+        self.write(self.ind + "}\n")
         
     def visit_constraint_solve_order(self, c:ConstraintSolveOrderModel):
         self.write(self.ind)

--- a/ve/unit/test_constraint_soft.py
+++ b/ve/unit/test_constraint_soft.py
@@ -277,31 +277,6 @@ class TestConstraintSoft(VscTestCase):
         pass
         
     def test_soft_nested(self):
-        @vsc.randobj
-        class Nested:
-            def __init__(self):
-                self.a = vsc.rand_uint8_t(8)
-                self.b = vsc.rand_uint8_t(8)
-                self.c = vsc.rand_uint8_t(8)
-
-            @vsc.constraint
-            def default_c(self):
-                self.a > 10
-                self.b == 20
-                self.c == 30
-                with vsc.if_then(self.a > 5):
-                    with vsc.if_then(self.a > 10):
-                        vsc.soft(self.b != 20)
-                    with vsc.implies(self.a > 10):
-                        vsc.soft(self.c != 30)
-
-        nested = Nested()
-
-        nested.randomize()
-        self.assertEqual(nested.b, 20)
-        self.assertEqual(nested.c, 30)
-
-    def test_soft_nested(self):
         """Test various nested soft constraint scenarios"""
 
         @vsc.randobj

--- a/ve/unit/test_constraint_soft.py
+++ b/ve/unit/test_constraint_soft.py
@@ -276,3 +276,69 @@ class TestConstraintSoft(VscTestCase):
         print(rand_a.a_field)
         pass
         
+    def test_soft_nested(self):
+        @vsc.randobj
+        class Nested:
+            def __init__(self):
+                self.a = vsc.rand_uint8_t(8)
+                self.b = vsc.rand_uint8_t(8)
+                self.c = vsc.rand_uint8_t(8)
+
+            @vsc.constraint
+            def default_c(self):
+                self.a > 10
+                self.b == 20
+                self.c == 30
+                with vsc.if_then(self.a > 5):
+                    with vsc.if_then(self.a > 10):
+                        vsc.soft(self.b != 20)
+                    with vsc.implies(self.a > 10):
+                        vsc.soft(self.c != 30)
+
+        nested = Nested()
+
+        nested.randomize()
+        self.assertEqual(nested.b, 20)
+        self.assertEqual(nested.c, 30)
+
+    def test_soft_nested(self):
+        """Test various nested soft constraint scenarios"""
+
+        @vsc.randobj
+        class Nested:
+            def __init__(self):
+                self.a = vsc.rand_uint8_t(8)
+                self.b = vsc.rand_uint8_t(8)
+                self.c = vsc.rand_uint8_t(8)
+                self.d = vsc.rand_uint8_t(8)
+                self.e = vsc.rand_uint8_t(8)
+                self.f = vsc.rand_uint8_t(8)
+                self.arr = vsc.rand_list_t(vsc.uint8_t(), 10)
+
+            @vsc.constraint
+            def default_c(self):
+                self.a > 10
+                self.b == 20
+                self.c == 30
+                vsc.soft(self.e == 50)
+                with vsc.implies(self.a == self.a):
+                    with vsc.if_then(self.a > 5):
+                        with vsc.if_then(self.a > 10):
+                            vsc.soft(self.b != 20)
+                            vsc.soft(self.d == 40)
+                            self.f == 60
+                        with vsc.implies(self.a > 10):
+                            vsc.soft(self.c != 30)
+                        with vsc.foreach(self.arr, idx=True) as i:
+                            vsc.soft(self.arr[i] == i)
+
+        nested = Nested()
+
+        nested.randomize(debug=1)
+        self.assertEqual(nested.b, 20)
+        self.assertEqual(nested.c, 30)
+        self.assertEqual(nested.d, 40)
+        self.assertEqual(nested.e, 50)
+        self.assertEqual(nested.f, 60)
+        for i in range(len(nested.arr)):
+            self.assertEqual(nested.arr[i], i)


### PR DESCRIPTION
This addresses #176 by first separating each soft constraint into its own Implies soft constraint while building RandInfo. The condition for the Implies constraint is built up by keeping a stack of the if_then and implies conditions while visiting constraints and combining those with And expressions.

Then in the RandSetNodeBuilder a soft_phase flag has been added to prevent nested soft constraints from being built during the hard constraints. A new soft constraints build phase is added to specifically build soft and nested soft constraints.

There's a TODO in rand_info_builder.py under visit_constraint_soft about how a 'priority' attribute is being added to the Implies constraint built up for nested soft constraints so that they can be sorted alongside other soft constraints as well as make it possible
to check for soft vs hard constraints in the add_constraints function.
```python3
            # TODO Is it okay to add priority attr to root Constraint so
            #      add_constraint can detect them and randomize can sort
            #      soft constraints more easily?
            soft_implies = ConstraintImpliesModel(and_cond, [c])
            soft_implies.priority = c.priority
            self._active_randset.add_constraint(soft_implies)
```

I should reread the docs, but the soft constraints section might need to be changed.