### PR TITLE
Fix deprecation and Enum issues for python 3.11; minordoc string fix

### DIFF
--- a/src/vsc/coverage.py
+++ b/src/vsc/coverage.py
@@ -820,7 +820,8 @@ class coverpoint(object):
 
                         for v in enum_bins.range_l:                        
                             e = ei.v2e_m[v[0]]
-                            self.model.add_bin_model(CoverpointBinEnumModel(str(e), v[0]))
+                            # IntEnum.__str__ returns the value rather than the name, use Enum.__str__ instead
+                            self.model.add_bin_model(CoverpointBinEnumModel(Enum.__str__(e), v[0]))
                             
                     elif isinstance(self.cp_t, type_base):
                         binspec = RangelistModel()

--- a/src/vsc/model/coverpoint_cross_model.py
+++ b/src/vsc/model/coverpoint_cross_model.py
@@ -93,7 +93,7 @@ class CoverpointCrossModel(CoverItemBase):
     
     def select_unhit_bin(self, r:RandIF)->int:
         if len(self.unhit_s) > 0:
-            return random.sample(self.unhit_s, 1)[0]
+            return random.sample(sorted(self.unhit_s), 1)[0]
         else:
             return -1
 

--- a/src/vsc/model/rand_info_builder.py
+++ b/src/vsc/model/rand_info_builder.py
@@ -159,7 +159,7 @@ class RandInfoBuilder(ModelVisitor,RandIF):
         return self._rng.randint(low,high)
     
     def sample(self, s, k):
-        return self._rng.sample(s, k)
+        return self._rng.sample(sorted(s), k)
     
     def visit_constraint_block(self, c):
         if RandInfoBuilder.EN_DEBUG:

--- a/src/vsc/types.py
+++ b/src/vsc/types.py
@@ -1102,7 +1102,7 @@ class rand_list_t(list_t):
         super().__init__(t, sz, is_rand=True)
         
 class randsz_list_t(list_t):
-    """List of random elements with a non-random size"""
+    """List of random elements with a random size"""
     
     def __init__(self, t):
         super().__init__(t, is_rand=True, is_randsz=True)

--- a/ve/unit/test_coverage_driven_constraints.py
+++ b/ve/unit/test_coverage_driven_constraints.py
@@ -24,7 +24,7 @@ class TestCoverageDrivenConstraints(VscTestCase):
                 return low
     
             def sample(self, s, k):
-                return random.sample(s, k)
+                return random.sample(sorted(s), k)
         
         
         @vsc.randobj


### PR DESCRIPTION
IntEnum.__str__ now returns a value rather than the full name. This creates the CoverpointBinEnumModel calling Enum.__str__ to replicate the full name it had before under python 3.10-.

Calling random.sample() on a set was deprecated in 3.11, this now follows the error message recommendation to cast it to sorted.

Minor docstring fix for randsz_list_t.