### PR TITLE
Remove high-priority, soft weight constraint from distributions

### DIFF
--- a/src/vsc/model/constraint_dist_scope_model.py
+++ b/src/vsc/model/constraint_dist_scope_model.py
@@ -3,9 +3,11 @@ Created on May 18, 2021
 
 @author: mballance
 '''
+from typing import List, Tuple
 from vsc.model.constraint_inline_scope_model import ConstraintInlineScopeModel
 from vsc.model.constraint_dist_model import ConstraintDistModel
 from vsc.model.constraint_soft_model import ConstraintSoftModel
+from vsc.model.rand_state import RandState
 
 class ConstraintDistScopeModel(ConstraintInlineScopeModel):
     """Holds implementation data about dist constraint"""
@@ -16,10 +18,36 @@ class ConstraintDistScopeModel(ConstraintInlineScopeModel):
         self.dist_c : ConstraintDistModel = dist_c
         
         self.dist_soft_c : ConstraintSoftModel = None
-        
-        # Indicates the current-target range. This is
-        # updated during the weight-selection process
+
+        # List of (weight, index) tuples
+        self.weight_list : List[Tuple[int, int]] = []
+        self.total_weight = 0
+
+        # Indicates the current-target range. This is used to
+        # by solvegroup_swizzler_range.
         self.target_range = 0
+
+    def next_target_range(self, randstate : RandState) -> int:
+        """Select the next target range from the weight list"""
+
+        seed_v = randstate.rng.randint(1, self.total_weight)
+
+        # Find the first range
+        i = 0
+        while i < len(self.weight_list):
+            seed_v -= self.weight_list[i][0]
+
+            if seed_v <= 0:
+                break
+
+            i += 1
+
+        if i >= len(self.weight_list):
+            i = len(self.weight_list)-1
+
+        self.target_range = self.weight_list[i][1]
+
+        return self.target_range
         
     def set_dist_soft_c(self, c : ConstraintSoftModel):
         self.addConstraint(c)

--- a/src/vsc/model/rand_set.py
+++ b/src/vsc/model/rand_set.py
@@ -21,11 +21,13 @@
 # @author: ballance
 
 from builtins import set
-from typing import Set, List
+from typing import Set, List, Dict
+from vsc.model.constraint_dist_scope_model import ConstraintDistScopeModel
 
 from vsc.model.constraint_model import ConstraintModel
 from vsc.model.field_model import FieldModel
 from vsc.model.constraint_soft_model import ConstraintSoftModel
+from vsc.model.field_scalar_model import FieldScalarModel
 from vsc.visitors.model_pretty_printer import ModelPrettyPrinter
 
 
@@ -43,7 +45,7 @@ class RandSet(object):
         self.soft_constraint_s : Set[ConstraintModel] = set()
         self.soft_constraint_l : List[ConstraintModel] = []
         self.soft_priority = 0
-        self.dist_field_m = {}
+        self.dist_field_m : Dict[FieldScalarModel, List[ConstraintDistScopeModel]] = {}
 
         # List of fields in each ordered set
         # Only non-none if order constraints impact this randset

--- a/src/vsc/model/rand_state.py
+++ b/src/vsc/model/rand_state.py
@@ -29,7 +29,7 @@ class RandState(object):
             
         return val
     
-    def randint(self, low, high):
+    def randint(self, low, high) -> int:
         low = int(low)
         high = int(high)
         

--- a/src/vsc/model/solvegroup_swizzler_range.py
+++ b/src/vsc/model/solvegroup_swizzler_range.py
@@ -11,6 +11,7 @@ from vsc.model.expr_fieldref_model import ExprFieldRefModel
 from vsc.model.expr_literal_model import ExprLiteralModel
 from vsc.model.expr_model import ExprModel
 from vsc.model.field_scalar_model import FieldScalarModel
+from vsc.model.rand_set import RandSet
 from vsc.model.variable_bound_model import VariableBoundModel
 
 
@@ -103,7 +104,10 @@ class SolveGroupSwizzlerRange(object):
         else:
             return False            
 
-    def swizzle_field(self, f, rs, bound_m) -> ExprModel:
+    def swizzle_field(self,
+                      f : FieldScalarModel, 
+                      rs : RandSet, 
+                      bound_m : VariableBoundModel)->ExprModel:
         ret = None
         
         if self.debug > 0:

--- a/ve/unit/test_constraint_soft.py
+++ b/ve/unit/test_constraint_soft.py
@@ -70,7 +70,7 @@ class TestConstraintSoft(VscTestCase):
                 it.a == 1 #B
 
     def test_soft_dist_priority(self):
-        """Ensures that dist constraints take priority over soft constraints"""
+        """Ensures that soft constraints take priority over dist constraints"""
         
         @vsc.randobj
         class my_item(object):
@@ -90,7 +90,7 @@ class TestConstraintSoft(VscTestCase):
                     vsc.weight(1,  10),
                     vsc.weight(2,  10),
                     vsc.weight(4,  10),
-                    vsc.weight(8, 10)])
+                    vsc.weight(8,  10)])
 
         hist = [0]*9
         item = my_item()
@@ -98,10 +98,10 @@ class TestConstraintSoft(VscTestCase):
             item.randomize()
             hist[item.a] += 1
 
-        self.assertGreater(hist[0], 0) 
-        self.assertGreater(hist[1], 0) 
-        self.assertGreater(hist[2], 0) 
-        self.assertGreater(hist[4], 0) 
+        self.assertEqual(hist[0], 0)
+        self.assertEqual(hist[1], 0)
+        self.assertEqual(hist[2], 0)
+        self.assertEqual(hist[4], 0)
         self.assertGreater(hist[8], 0) 
 
     def test_compound_array(self):


### PR DESCRIPTION
This removes the soft constraint created after building the hard constraints for a distribution. It also reverses the unittest meant for testing that distribution non-zero weights can override soft constraints.

This saves off the weight list and a function to calculate them into ConstraintDistScopeModel, in the hopes that at some point recalling the randomization model and swizzler would re-randomize the distribution weight targeted.

This also adds enough type hints to make it easier to track down target_range and distribution weight list usage.