### PR TITLE
Improve Performance of source_info.mk()

### DIFF
--- a/src/vsc/model/source_info.py
+++ b/src/vsc/model/source_info.py
@@ -25,7 +25,7 @@ class SourceInfo(object):
         if len(stack) <= (levels+1):
             raise Exception("requested stack frame %d out-of-bounds (%d)" % (
                 levels, len(stack)))
-        frame = inspect.stack()[levels+1]
+        frame = stack[levels+1]
         
         return cls(frame.filename, frame.lineno)
     


### PR DESCRIPTION
Inspect.stack is a resource intensive call as it recursively gets all the context for every stack frame (see https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow). By only calling it once, I was able to cut the time spent in calls to the `vsc.constraint` decorator in half.