### PR TITLE
Solve-order fixes

### DIFF
--- a/doc/source/constraints.rst
+++ b/doc/source/constraints.rst
@@ -488,9 +488,18 @@ statement corresponds to the SystemVerilog `solve a before b` statement.
                 with vsc.else_then:
                     self.b != 4
 
-In the example above, te `solve_order` statement causes `b` to
+In the example above, the `solve_order` statement causes `b` to
 have values evenly distributed between the value sets [4] and 
 [0..3,5..255].
+
+Use lists of variables to create multiple solve-order constraints.
+The example below solves `a` and `b` before `c` and `d`.
+
+.. code-block:: python3
+
+            @vsc.constraint
+            def abcd_c(self):
+                vsc.solve_order([self.a, self.b], [self.c, self.d])
 
 unique
 ------

--- a/src/vsc/constraints.py
+++ b/src/vsc/constraints.py
@@ -431,7 +431,7 @@ def solve_order(before, after):
             a_e = pop_expr()
             if not isinstance(a_e, ExprFieldRefModel):
                 raise Exception("Parameter " + str(a) + " is not a field reference")
-            before_l.append(a_e.fm)
+            after_l.append(a_e.fm)
     else:
         to_expr(after)
         after_e = pop_expr()

--- a/src/vsc/model/rand_info_builder.py
+++ b/src/vsc/model/rand_info_builder.py
@@ -98,11 +98,15 @@ class RandInfoBuilder(ModelVisitor,RandIF):
             
         builder = RandInfoBuilder(rng)
 
-        # First, collect all the fields
+        # First, collect all fields and ordering from constraints
         builder._pass = 0
         for fm in field_model_l:
             fm.accept(builder)
-            
+
+        # Collect all fields and ordering from standalone constraints passed to the function
+        for c in constraint_l:
+            c.accept(builder)
+
         builder._randset_m.clear()
         builder._randset_l.clear()
         builder._randset_field_m.clear()


### PR DESCRIPTION
This fixes two issues:
- Solve-order constraints being ignored in with statements.
- A copy-paste typo: #213

Also added a unit test to cover both features.