### PR TITLE
Merge dists when combining randsets

### DIFF
--- a/src/vsc/model/rand_info_builder.py
+++ b/src/vsc/model/rand_info_builder.py
@@ -390,6 +390,12 @@ class RandInfoBuilder(ModelVisitor,RandIF):
                     self._randset_field_m[f] = ex_randset
                     ex_randset.add_field(f)
 
+                for f, s in self._active_randset.dist_field_m.items():
+                    if f in ex_randset.dist_field_m.keys():
+                        ex_randset.dist_field_m[f].extend(s)
+                    else:
+                        ex_randset.dist_field_m[f] = s
+
                 for c in self._active_randset.constraints():
                     ex_randset.add_constraint(c)
                     

--- a/ve/unit/test_constraint_dist.py
+++ b/ve/unit/test_constraint_dist.py
@@ -254,6 +254,43 @@ class TestConstraintDist(VscTestCase):
                 self.fail("Value " + str(c.a) + " illegal")
         print("hist: " + str(hist))
 
+    def test_dist_multiple_dists_in_randset(self):
+
+        @vsc.randobj
+        class my_c(object):
+
+            def __init__(self):
+                self.a = vsc.rand_bit_t()
+                self.b = vsc.rand_bit_t()
+                self.en = vsc.rand_bit_t()
+
+            @vsc.constraint
+            def multi_dists(self):
+                vsc.dist(self.a, [
+                    vsc.weight(0, 1),
+                    vsc.weight(1, 99999)])
+                vsc.dist(self.b, [
+                    vsc.weight(0, 1),
+                    vsc.weight(1, 99999)])
+                with vsc.implies(self.en == 0):
+                    self.a == 0
+                    self.b == 0
+
+        c = my_c()
+
+        hist = 2*[0]
+
+        for i in range(100):
+            with c.randomize_with() as it:
+                it.en == 1
+            hist[0] += c.a
+            hist[1] += c.b
+
+        print("hist: " + str(hist))
+        for h in hist:
+            self.assertGreater(h, 95)
+
+
     def test_dist_array_elems(self):
 
         @vsc.randobj 


### PR DESCRIPTION
When two randsets with dist constraints combined the dists from the current randset were getting lost. This meant that for two related variables with dists that only the last dist was ever used in the randomization/swizzler.

This adds or merges the dist_field_m dict entries to the existing randset to retain them.

Added a test case that ties two variables together with an enable bit conditional.